### PR TITLE
[20250813] 수학문제풀이/ eoyeou

### DIFF
--- a/eoyeou/수학/20250813/BOJ_1788_ys.py
+++ b/eoyeou/수학/20250813/BOJ_1788_ys.py
@@ -1,0 +1,25 @@
+def fibo(n):
+    if 0 <= n < 2 :
+        return n
+    elif n >= 2 :
+        return fibo(n-1)+fibo(n-2)
+    else:
+
+        # return fibo(n) * ((-1) **(n+1))   #-> maximum recursion depth exceeded 오류,,,,,
+        sign = -1 if abs(n) % 2 == 0 else 1     #짝수면 부호가 -1, 홀수면 1
+        return sign * fibo(-n)
+    
+def fibo_print(n):
+    if fibo(n) > 0 :
+        print(1)
+    elif fibo(n) == 0 :
+        print(0)
+    else: print(-1)
+
+
+n = int(input())
+fibo_print(n)
+result = abs(fibo(n))%1000000000
+print(result)
+
+#런타임 에러............

--- a/hemu/배열/20250812/SWEA_풍선펑.py
+++ b/hemu/배열/20250812/SWEA_풍선펑.py
@@ -1,0 +1,17 @@
+T = int(input())
+for tc in range(1,T+1):
+    N = int(input())
+    pung = [list(map(int, input().split())) for _ in range(N)]
+    max_pung = 0
+    for x in range(N):
+        for y in range(N):
+            s = pung[x][y]
+            num = [[1,0],[-1,0],[0,1],[0,-1]]
+            for dx, dy in num:
+                for z in range(1,N):
+                    nx, ny = x+dx*z, y+dy*z
+                    if 0<=nx<N and 0<=ny<N:
+                        s+=pung[nx][ny]
+                if s>max_pung:
+                    max_pung = s
+    print(f"#{tc} {max_pung}")

--- a/jh/수학/BOJ_2566_최댓값.py
+++ b/jh/수학/BOJ_2566_최댓값.py
@@ -1,0 +1,14 @@
+N = [list(map(int, input().split())) for _ in range(9)]
+max_v = 0
+idx_row = 0
+idx_col = 0
+cur_row = 0
+for i in N[:]:
+    if max_v < max(i):
+        max_v = max(i)
+        idx_row = cur_row # 행의 인덱스를 카운트
+        idx_col = i.index(max(i)) # 열의 인덱스
+    cur_row += 1
+
+print(max_v)
+print(idx_row + 1, idx_col + 1) # 문제에서 요구하는 행과 열은 1행 1열부터 시작

--- a/sm/배열/오목판정.py
+++ b/sm/배열/오목판정.py
@@ -1,0 +1,25 @@
+T = int(input())
+for case in range(1,T+1):
+    N = int(input())
+    arr = [list(input())for _ in range(N)]
+
+    ans = 0
+    delta = [[0,1],[1,0],[1,1],[-1,1]] #기준점이 왼쪽 위이기 때문에 우,하,우하,우상 만 해도 가능
+    for i in range(N):
+        for j in range(N):
+
+
+            if arr[i][j] == 'o': # 좌표가 'o'일때만 찾아보기
+                for di,dj in delta:
+                    value = []
+                    for c in range(1,5): #본인 좌표 제외
+                        ni,nj = i+di*c, j+dj*c
+                        if 0<=ni<N and 0<=nj<N:
+                            value.append(arr[ni][nj])
+                    # print(value),테스트용
+                    if value.count('o') ==4:  #'o'가 4개라면 5개 연속
+                        ans += 1
+    if ans == 0:
+        print(f'#{case} NO')
+    else:
+        print(f'#{case} YES')

--- a/yj-yuee/구현/250812/스위치조작.py
+++ b/yj-yuee/구현/250812/스위치조작.py
@@ -1,0 +1,30 @@
+T = int(input())
+for ts in range(T):
+    N = int(input())
+
+    def compare(p_lst, e_lst):
+        for i in range(len(p_lst)) :
+            if p_lst[i] != e_lst[i]: #두개가 다르면 여기가 시작 인덱스
+                start = i
+                return True, start
+        return 0,0
+
+    def reverse(n, p_lst):
+        for j in range(N - 1, n - 1, -1):# 뒤부터 바뀐인덱스까지 0,1바꾸기
+            p_lst[j] = 1 - p_lst[j]
+        return p_lst
+
+
+    pre_switches = list(map(int, input().split()))
+    end_switches = list(map(int, input().split()))
+    cnt = 0
+    #두개가 다를동안 반복
+    while pre_switches != end_switches:
+        #다른 첫지점을 찾는다 여기가 뒤집을 위치
+        check, start_idx = compare(pre_switches,end_switches)
+        #그다음 부터는 바뀐리스트랑 비교해야함 바꾸고 카운트 +1
+        reverse(start_idx, pre_switches)#파이썬의 특징 때문에 재재정은 하지않음
+        cnt += 1
+
+    # end랑 같아졌다면 끝 내고 cnt값 출력
+    print(f'#{ts+1} {cnt}')


### PR DESCRIPTION
# 🧮 알고리즘 문제 해결 PR

## 📝 문제 정보
- **문제 제목**: 피보나치 수의 확장
- **문제 링크**: https://www.acmicpc.net/problem/1788
- **플랫폼**: 백준
- **난이도**: 실버

## 🎯 사용한 알고리즘
- [ ] 브루트포스 [ ] 그리디 [ ] DP [ ] DFS/BFS [ ] 이분탐색 [ ] 기타:

## 🔍 풀이 과정
### 문제 이해
- 음수까지 확장된 피보나치 함수를 정의하고 주어진 n에 대해 부호와 절댓값을 구하는 문제
- 결과는 절댓값에서 1000000000으로 나눈 나머지 출력

### 접근 방법
- n이 양수일 경우 일반 피보나치 함수
- n이 음수일 경우 부호를 결정하고 양수 n의 피보나치 절댓값을 구한 뒤 적용

### 구현에서 어려웠던 점
- 재귀 방식을 쓰니까 런타임 에러가 발생한 듯..
- 런타임 에러를 수정하지 못했다,,

## ⏱️ 복잡도
- **시간**: O()  **공간**: O()

## 💡 핵심 아이디어
- 음수 피보나치의 부호 : 짝수는 -, 홀수는 +

## 🤔 회고

### 다음에는?
- 재귀보다는 반복문으로 풀어야겠다..

## ✅ 체크리스트
- [x] 주석 작성 완료
- [ ] 엣지케이스 고려
- [ ] 복잡도 분석 완료
