### PR TITLE
[250813] 수학문제풀이 / jxn-hxxn

### DIFF
--- a/jh/수학/BOJ_2566_최댓값.py
+++ b/jh/수학/BOJ_2566_최댓값.py
@@ -1,0 +1,14 @@
+N = [list(map(int, input().split())) for _ in range(9)]
+max_v = 0
+idx_row = 0
+idx_col = 0
+cur_row = 0
+for i in N[:]:
+    if max_v < max(i):
+        max_v = max(i)
+        idx_row = cur_row
+        idx_col = i.index(max(i))
+    cur_row += 1
+
+print(max_v)
+print(idx_row + 1, idx_col + 1)

--- a/jh/수학/BOJ_2566_최댓값.py
+++ b/jh/수학/BOJ_2566_최댓값.py
@@ -6,9 +6,9 @@ cur_row = 0
 for i in N[:]:
     if max_v < max(i):
         max_v = max(i)
-        idx_row = cur_row
-        idx_col = i.index(max(i))
+        idx_row = cur_row # 행의 인덱스를 카운트
+        idx_col = i.index(max(i)) # 열의 인덱스
     cur_row += 1
 
 print(max_v)
-print(idx_row + 1, idx_col + 1)
+print(idx_row + 1, idx_col + 1) # 문제에서 요구하는 행과 열은 1행 1열부터 시작

--- a/week_algorithm/week_quest_3/jh_피보나치의수.py
+++ b/week_algorithm/week_quest_3/jh_피보나치의수.py
@@ -22,4 +22,5 @@ print(sign)
 if n != 0:
     print(fibo[k] % mod_num)
 else:
-    print(0)
+    print(0)  
+    

--- a/week_algorithm/week_quest_3/jh_피보나치의수.py
+++ b/week_algorithm/week_quest_3/jh_피보나치의수.py
@@ -1,0 +1,25 @@
+n = int(input())
+mod_num = 1000000000
+k = abs(n)  # 절댓값으로 양수 피보나치 계산
+fibo = [0] * (k + 2)  # 인덱스 에러 방지
+fibo[0] = 0
+fibo[1] = 1
+for i in range(2, k + 1):
+    fibo[i] = (fibo[i - 1] + fibo[i - 2]) % mod_num
+
+if n > 0: # n이 양수면 1
+    sign = 1
+elif n < 0: # n이 음수면
+    if k % 2 == 1: # 절대값이 홀수일 때
+        sign = 1 
+    else: # 절대값이 양수일 때
+        sign = -1
+else:  # n이 0일 때
+    sign = 0
+
+print(sign)
+
+if n != 0:
+    print(fibo[k] % mod_num)
+else:
+    print(0)


### PR DESCRIPTION
# 🧮 알고리즘 문제 해결 PR

## 📝 문제 정보
- **문제 제목**: 피보나치 수의 확장
- **문제 링크**: https://www.acmicpc.net/problem/1788
- **플랫폼**: BOJ
- **난이도**: 실버3

## 🎯 사용한 알고리즘
- [ ] 브루트포스 [ ] 그리디 [ ] DP [ ] DFS/BFS [ ] 이분탐색 [ ] 기타:

## 🔍 풀이 과정
### 문제 이해
음수로도 확장한 피보나치 수에 대한 문제이다.

### 접근 방법
피보나치 수열을 재귀 방법을 사용해서 풀었다.

### 구현에서 어려웠던 점
n이 음수일 때 절대값이 짝수인 경우와 홀수인 경우로 나눠서 생각해아 하는 것이 어려웠다.

## ⏱️ 복잡도
- **시간**: O()  **공간**: O()

## 💡 핵심 아이디어
기본적으로 재귀함수를 사용하고, n이 음수인 경우 절대값이 짝수인 경우와 홀수인 경우 부호가 다른 것을 확인하고 적용했다.

## 🤔 회고
### 어려웠던 점
n이 음수인 경우 확인하는 것이 어려웠다.

### 배운 점
수업시간에도 다룬 피보나치 수열을 음수인 경우까지 확장할 수 있었다.

### 다음에는?
내가 작성한 방법이 아닌 다른 방법으로도 풀고싶다.

## ✅ 체크리스트
- [ ] 주석 작성 완료
- [ ] 엣지케이스 고려
- [ ] 복잡도 분석 완료
