### PR TITLE
[250813] 기타문제풀이 / eoyeou

### DIFF
--- a/eoyeou/문자열/20250812/SWEA_3143_ys.py
+++ b/eoyeou/문자열/20250812/SWEA_3143_ys.py
@@ -1,0 +1,52 @@
+def pattern_lps(pattern):
+    #패턴의 LPS 생성
+    lps = [0] * len(pattern)
+    length = 0  # 현재까지 일치한 접두사 길이
+
+    for i in range(1, len(pattern)):
+        while length > 0 and pattern[i] != pattern[length]:
+            length = lps[length - 1]
+        if pattern[i] == pattern[length]:
+            length += 1
+            lps[i] = length
+    return lps
+
+def kmp_search(text, pattern):
+    #패턴이 시작되는 모든 위치 반환
+    if not pattern:
+        return []
+    lps = pattern_lps(pattern)
+    match_starts = []
+    j = 0  # 패턴 인덱스
+
+    for i in range(len(text)):
+        while j > 0 and text[i] != pattern[j]:
+            j = lps[j - 1]
+        if text[i] == pattern[j]:
+            j += 1
+            if j == len(pattern):
+                match_starts.append(i - len(pattern) + 1)
+                j = lps[j - 1]
+    return match_starts
+
+T = int(input())
+for case_num in range(1, T + 1):
+    text, pattern = input().split()
+
+    # KMP로 모든 매치 시작 위치 찾기
+    match_starts = kmp_search(text, pattern)
+
+    # 겹치지 않게 최대 매치 선택
+    match_count = 0
+    last_end_index = -1
+    pattern_len = len(pattern)
+
+    for start_index in match_starts:
+        if start_index >= last_end_index:
+            match_count += 1
+            last_end_index = start_index + pattern_len
+
+    # 최소 키 입력 횟수 계산
+    min_key = len(text) - match_count * (pattern_len - 1)
+
+    print(f"#{case_num} {min_key}")


### PR DESCRIPTION
# 🧮 알고리즘 문제 해결 PR

## 📝 문제 정보
- **문제 제목**: 점점 커지는 당근의 개수
- **문제 링크**: https://swexpertacademy.com/main/code/userProblem/userProblemDetail.do?contestProbId=AW_nY2m6OLADFARY
- **플랫폼**: SWEA
- **난이도**: D1

## 🎯 사용한 알고리즘
- [ ] 브루트포스 [ ] 그리디 [ ] DP [ ] DFS/BFS [ ] 이분탐색 [ ] 기타:

## 🔍 풀이 과정
### 문제 이해
- 당근이 연속해서 증가하는 구간의 최대 길이 구하기
- 같은 값이 연속이거나 감소하면 그 지점에서 증가 구간 끊어야


### 접근 방법
- 처음에는 숫자들이 증가 -> 감소 -> 증가일 경우 증가의 크기를 비교하기 위해 리스트에 담았다.
- 그런데 굳이 리스트에 담을 필요 없이 변수로 크기 비교를 할 수 있었다..


## ⏱️ 복잡도
- **시간**: O()  **공간**: O()

## 💡 핵심 아이디어
- 증가 조건에 등호는 포함되지 않는다.
- 마지막 구간을 반영하기 위해서 루프 후에 갱신 해줘야 

## 🤔 회고
### 어려웠던 점
- 처음에 증가하는 조건 외에 등호 조건을 빼먹어서 테스트케이스 10개 중 9개만 통과했다.

### 다음에는?
- 다른 기출 문제도 풀어보기..

## ✅ 체크리스트
- [ ] 주석 작성 완료
- [ ] 엣지케이스 고려
- [ ] 복잡도 분석 완료
