### PR TITLE
[250820] 수학 문제 풀이 / jxn-hxxn

### DIFF
--- a/week_algorithm/week_quest_4/jh_피보나치_함수.py
+++ b/week_algorithm/week_quest_4/jh_피보나치_함수.py
@@ -1,0 +1,64 @@
+''' 풀 재귀 함수 - 시간 초과
+def fibonacci(n):
+    global cnt_0, cnt_1
+
+    if n == 0:
+        cnt_0 += 1
+        return 0
+    elif n == 1:
+        cnt_1 += 1
+        return 1
+    else:
+        return fibonacci(n - 1) + fibonacci(n - 2)
+
+T = int(input())
+for test_case in range(1, T + 1):
+    N = int(input())
+    cnt_0 = 0
+    cnt_1 = 0
+    fibonacci(N)
+
+    print(cnt_0, cnt_1)
+'''
+''' 재귀 함수_메모이제이션 - 상위 값이 메모리로 저장되기 때문에 호출 횟수를 구할 수 없음
+def fibonacci_memo(n):
+    global cnt_0, cnt_1, memo
+
+    if n == 0:
+        cnt_0 += 1
+        return 0
+    if n == 1:
+        cnt_1 += 1
+        return 1
+    if n in memo:
+        return memo[n]
+
+    memo[n] = fibonacci_memo(n - 1) + fibonacci_memo(n - 2)
+
+    return memo[n]
+
+T = int(input())
+for test_case in range(1, T + 1):
+    N = int(input())
+    cnt_0 = 0
+    cnt_1 = 0
+    memo = {}
+    fibonacci_memo(N)
+
+    print(cnt_0, cnt_1)
+'''
+# 재귀 함수_DP(동적 계획) - 32412KB, 36ms
+def fibonacci_DP(n):
+    fibo = [0, 1]
+    for i in range(2, n + 1):
+        fibo.append(fibo[i - 1] + fibo[i - 2])
+
+    return [fibo[n - 1], fibo[n]]
+
+T = int(input())
+for test_case in range(1, T + 1):
+    N = int(input())
+    cnt_0 = 0
+    cnt_1 = 0
+
+    print(f"{' '.join(map(str, fibonacci_DP(N)))}")


### PR DESCRIPTION
# 🧮 알고리즘 문제 해결 PR

## 📝 문제 정보
- **문제 제목**: 피보나치 함수
- **문제 링크**: https://www.acmicpc.net/problem/1003
- **플랫폼**: BOJ
- **난이도**: 실버 3

## 🎯 사용한 알고리즘
- [ ] 브루트포스 [ ] 그리디 [ ] DP [ ] DFS/BFS [ ] 이분탐색 [ ] 기타:

## 🔍 풀이 과정
### 문제 이해
피보나치를 구하는 함수가 주어졌을 때 n = 1 이 출력되는 횟수와 n = 0 이 출력되는 횟수를 출력한다.

### 접근 방법
재귀 함수 구하는 세가지 방법으로 모두 접근해봤다.
기본 재귀 함수, 메모이제이션 사용, DP 사용

### 구현에서 어려웠던 점
멍청한 chatgpt 때문에 이상한 곳에서 시간을 좀 낭비했다.
메모이제이션 방법을 사용하면 0과 1이 호출되는 횟수를 구하지 못하는데 자꾸 구할 수 있다고 우긴다.

## ⏱️ 복잡도
- **시간**: O()  **공간**: O()

## 💡 핵심 아이디어
기본 피보나치 재귀 함수에 0과 1이 호출되는 횟수를 세는 코드를 추가한다.

## 🤔 회고
### 어려웠던 점
DP를 사용한 재귀함수에서 0과 1을 호출하는 횟수를 어떻게 구해야 할까 고민했다.

### 배운 점
chatgpt는 멍청하다.

### 다음에는?
chatgpt는 믿지 않을 것이다.

## ✅ 체크리스트
- [ ] 주석 작성 완료
- [ ] 엣지케이스 고려
- [ ] 복잡도 분석 완료
