### PR TITLE
[250922] bfs / jxn-hxxn

### DIFF
--- a/jh/dfs/BOJ_1245.py
+++ b/jh/dfs/BOJ_1245.py
@@ -1,0 +1,48 @@
+# 주변에 높은게 있으면 return
+# 같으면 스택에 append
+# 주변에 낮은 것만 있으면 + 1
+
+def dfs(s_i, s_j):
+    global cnt
+    stack = []
+    stack.append((s_i, s_j))
+    visited[s_i][s_j] = True
+
+    while stack:
+        (vi, vj) = stack.pop()
+        # 8방향 델타
+        for di, dj in [(0, 1), (1, 0), (0, -1), (-1, 0), (1, 1), (1, -1), (-1, 1), (-1, -1)]:
+            new_i = vi + di
+            new_j = vj + dj
+            # 델타 중 arr[vi][vj] 보다 큰 것이 있으면 return
+            if 0 <= new_i < N and 0 <= new_j < M and not visited[new_i][new_j] and arr[new_i][new_j] > arr[vi][vj]:
+                return
+            # 델타 중 arr[vi][vj] 랑 같으면 append하고 visited 
+            elif 0 <= new_i < N and 0 <= new_j < M and not visited[new_i][new_j] and arr[new_i][new_j] == arr[vi][vj]:
+                stack.append((new_i, new_j))
+                visited[new_i][new_j] = True
+                # 만약 이미 봉우로리 카운트 된 좌표를 만나면 return
+                if (new_i, new_j) in cnt_grid:
+                    return
+            # 델타 중 arr[vi][vj] 보다 작으면 continue    
+            elif 0 <= new_i < N and 0 <= new_j < M and not visited[new_i][new_j] and arr[new_i][new_j] < arr[vi][vj]:
+                continue
+    # while 문이 다 돌면 봉우리 수 cnt + 1
+    cnt += 1
+    # 시작 좌표 cnt_grid 리스트에 append
+    cnt_grid.append((s_i, s_j))
+
+    return
+
+
+
+N, M = map(int, input().split())
+arr = [list(map(int, input().split())) for _ in range(N)]
+cnt = 0
+cnt_grid = []
+for i in range(N):
+    for j in range(M):
+        visited = [[False] * M for _ in range(N)]
+        dfs(i, j)
+
+print(cnt)


### PR DESCRIPTION
# 🧮 알고리즘 문제 해결 PR

## 📝 문제 정보
- **문제 제목**: 농장 관리
- **문제 링크**: https://www.acmicpc.net/problem/1245
- **플랫폼**: BOJ
- **난이도**: 골드 5

## 🎯 사용한 알고리즘
- [ ] 브루트포스 [ ] 그리디 [ ] DP [ ] DFS/BFS [ ] 이분탐색 [ ] 기타:

## 🔍 풀이 과정
### 문제 이해
주어진 배열에서 주변에 비해 높이가 높은 봉우리의 개수를 구하라.

### 접근 방법
dfs 스택을 사용해 해당 좌표보다 주변 좌표가 큰 경우, 같은 경우, 작은 경우를 나누어 접근했다.

### 구현에서 어려웠던 점
같은 높이의 좌표 여러개로 이루어진 봉우리의 경우 한번 카운트한 봉우리를 제외하는 것이 조금 까다로웠다.

## ⏱️ 복잡도
- **시간**: O()  **공간**: O()

## 💡 핵심 아이디어
dfs 스택을 사용한 것과 주변 좌표와의 크기를 비교하는 범위를 설정하는 것

## 🤔 회고
### 어려웠던 점
좌표별로 dfs를 실행해 봉우리를 카운트 할 때 이미 카운트한 봉우리를 제외하는 것을 구현하는것.

### 배운 점
dfs 복습을 했다.

### 다음에는?
시간을 더 줄이는 방법을 고민해 코드를 작성해 보아야겠다.

## ✅ 체크리스트
- [ ] 주석 작성 완료
- [ ] 엣지케이스 고려
- [ ] 복잡도 분석 완료
