### PR TITLE
[251004] dfs / jxn-hxxn

### DIFF
--- a/jh/수학/BOJ_16234.py
+++ b/jh/수학/BOJ_16234.py
@@ -1,0 +1,61 @@
+def dfs(s_i, s_j):
+    global is_moved
+    # stack 사용
+    stack = []
+    stack.append((s_i, s_j))
+    visited[s_i][s_j] = True
+    # 국경이 연결된 지역의 인구수, 나라 수, 좌표 리스트를 활용
+    tmp_sum = arr[s_i][s_j]
+    tmp_cnt = 1
+    tmp_list = []
+    tmp_list.append((s_i, s_j))
+    while stack:
+        vi, vj = stack.pop()
+        for di, dj in [(0, 1), (1, 0), (0, -1), (-1, 0)]:
+            new_i = vi + di
+            new_j = vj + dj
+            if 0 <= new_i < N and 0 <= new_j < N and not visited[new_i][new_j]:
+                tmp_diff = abs(arr[vi][vj] - arr[new_i][new_j])
+                if L <= tmp_diff <= R:
+                    stack.append((new_i, new_j))
+                    visited[new_i][new_j] = True
+                    tmp_sum += arr[new_i][new_j]
+                    tmp_cnt += 1
+                    tmp_list.append((new_i, new_j))
+    # 만약 이번 dfs로 True로 변경된 나라의 수가 2개 이상이면
+    if tmp_cnt >= 2:
+        # arr 업데이트
+        after_move = tmp_sum // tmp_cnt
+        for i, j in tmp_list:
+            arr[i][j] = after_move
+        # is_moved True
+        is_moved = True
+
+    return visited
+
+
+N, L, R = map(int, input().split())
+arr = [list(map(int, input().split())) for _ in range(N)]
+visited = [[False] * N for _ in range(N)]
+
+# 결과
+result = 0
+
+while True:
+    # 인구 이동이 일어났는지 체크하는 is_moved 초기값 설정
+    is_moved = False
+    # visited 초기화
+    visited = [[False] * N for _ in range(N)]
+    # 전체 좌표를 탐색
+    for i in range(N):
+        for j in range(N):
+            # 방문하지 않은 곳의 좌표에 대해 dfs 수행
+            if not visited[i][j]:
+                visited = dfs(i, j)
+    # 모든 좌표 탐색 후 인구 이동이 일어나지 않았으면 break, 인구이동이 일어났으면 result += 1
+    if not is_moved:
+        break
+    else:
+        result += 1
+
+print(result)


### PR DESCRIPTION
# 🧮 알고리즘 문제 해결 PR

## 📝 문제 정보
- **문제 제목**: 인구 이동
- **문제 링크**: https://www.acmicpc.net/problem/16234
- **플랫폼**: BOJ
- **난이도**: 골드 4

## 🎯 사용한 알고리즘
- [ ] 브루트포스 [ ] 그리디 [ ] DP [ ] DFS/BFS [ ] 이분탐색 [ ] 기타:

## 🔍 풀이 과정
### 문제 이해
주어진 배열에 대해 일정 조건에 의해 국경이 열리고 인구 이동이 일어난다.
인구 이동이 일어나는 횟수를 구한다.

### 접근 방법
dfs를 활용해 시작 좌표에서 국경이 열린 좌표들을 구하고, 인구를 재배치한다.

### 구현에서 어려웠던 점
visited를 초기화 하는 시점과 인구를 계산하고 적용하는 좌표를 설정하는 기준에 대해 고민을 많이 했다.

## ⏱️ 복잡도
- **시간**: O()  **공간**: O()

## 💡 핵심 아이디어
기본적으로 dfs를 활용하여 visited,를 초기화 하는 시점이 중요했다.

## 🤔 회고
### 어려웠던 점
visited를 초기화 하는 시점과 인구를 계산하고 적용하는 좌표를 설정하는 기준에 대해 고민을 많이 했다.

### 배운 점
dfs 복습

### 다음에는?
알고리즘을 자주 안풀어서 구현 속도가 느렸던 것 같다.
더 빨리 풀 수 있도록 노력해야겠다.

## ✅ 체크리스트
- [ ] 주석 작성 완료
- [ ] 엣지케이스 고려
- [ ] 복잡도 분석 완료
